### PR TITLE
Removing this.get on all the individual props, added propTypes

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,6 +2,8 @@
   "predef": [
     "document",
     "window",
+    "jQuery",
+    "$",
     "-Promise"
   ],
   "browser": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -2,8 +2,6 @@
   "predef": [
     "document",
     "window",
-    "jQuery",
-    "$",
     "-Promise"
   ],
   "browser": true,

--- a/addon/components/ember-slider.js
+++ b/addon/components/ember-slider.js
@@ -14,19 +14,10 @@ export default Ember.Component.extend({
 	didInsertElement: function() {
 		this._super.apply(this, arguments);
 
-		var self   = this;
-		var target = this.get('actionTarget') || this;
+		var self    = this;
+		var target  = this.get('actionTarget') || this;
 
-		this.$().slider({
-			animate : this.get('animate'),
-			disabled : this.get('disabled'),
-			max : this.get('max'),
-			min : this.get('min'),
-			orientation : this.get('orientation'),
-			range : this.get('range'),
-			step : this.get('step'),
-			value : this.get('value'),
-			values : this.get('values'),
+		var options = Ember.$.extend({}, this.getProperties(props), {
 			slide : function(event, ui) {
 				self.set('value', ui.value);
 			},
@@ -38,6 +29,8 @@ export default Ember.Component.extend({
 				}
 			}
 		});
+
+		this.$().slider(options);
 
 		this.registerListeners();
 	},

--- a/addon/components/ember-slider.js
+++ b/addon/components/ember-slider.js
@@ -17,7 +17,7 @@ export default Ember.Component.extend({
 		var self    = this;
 		var target  = this.get('actionTarget') || this;
 
-		var options = Ember.$.extend({}, this.getProperties(props), {
+		var options = Ember.merge(this.getProperties(props), {
 			slide : function(event, ui) {
 				self.set('value', ui.value);
 			},

--- a/addon/components/ember-slider.js
+++ b/addon/components/ember-slider.js
@@ -11,7 +11,6 @@ export default Ember.Component.extend({
 		orientation: String,
 		max:         Number,
 		min:         Number,
-		range:       Boolean,
 		disabled:    Boolean,
 		value:       Number,
 		step:        Number

--- a/addon/components/ember-slider.js
+++ b/addon/components/ember-slider.js
@@ -1,11 +1,21 @@
 import Ember from 'ember';
 
-var props = Object.keys($.ui.slider._proto.options);
+var props = Object.keys(Ember.$.ui.slider._proto.options);
 
 export default Ember.Component.extend({
 	classNames:   ['silder'],
 	changeAction: null,
 	actionTarget: null,
+	
+	propTypes: {
+		orientation: String,
+		max:         Number,
+		min:         Number,
+		range:       Boolean,
+		disabled:    Boolean,
+		value:       Number,
+		step:        Number
+	},
 
 	didInsertElement: function() {
 		this._super.apply(this, arguments);
@@ -14,10 +24,10 @@ export default Ember.Component.extend({
 		var target  = this.get('actionTarget') || this;
 
 		var options = Ember.merge(this.getProperties(props), {
-			slide : function(event, ui) {
+			slide : function (event, ui) {
 				self.set('value', ui.value);
 			},
-			change : function(event, ui) {
+			change : function (event, ui) {
 				if (target.sendAction) {
 					target.sendAction('changeAction', ui.value);
 				} else {
@@ -38,7 +48,14 @@ export default Ember.Component.extend({
 	},
 
 	proxySlider: function (target, key) {
-		this.$().slider('option', key, this.get(key));
+		var propType = this.propTypes[key];
+		var value    = this.get(key);
+
+		if (propType) {
+			value = propType(value);
+		}
+
+		this.$().slider('option', key, value);
 	},
 
 	registerListeners: function () {

--- a/addon/components/ember-slider.js
+++ b/addon/components/ember-slider.js
@@ -1,10 +1,6 @@
 import Ember from 'ember';
 
-var props = [
-	'animate', 'disabled', 'max',
-	'min', 'orientation', 'range', 'step',
-	'value', 'values'
-];
+var props = Object.keys($.ui.slider._proto.options);
 
 export default Ember.Component.extend({
 	classNames:   ['silder'],

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,9 +1,9 @@
 <div class="row">
-    <div class="col-xs-12 form-horizontal">
-    	<div class="form-group">
-		    <label class="col-sm-2"></label>
-		    <div class="col-sm-10">
-		    	{{#if isRange}}
+	<div class="col-xs-12 form-horizontal">
+		<div class="form-group">
+			<label class="col-sm-2"></label>
+			<div class="col-sm-10">
+				{{#if isRange}}
 					{{ember-slider
 					 	values=sliderVals
 					 	disabled=isDisabled
@@ -17,37 +17,37 @@
 				{{/if}}
 			</div>
 		</div>
-	    {{#if isRange}}
-	        <div class="form-group">
-		    <label class="col-xs-2">Values</label>
-		    <div class="col-xs-10">
+		{{#if isRange}}
+			<div class="form-group">
+			<label class="col-xs-2">Values</label>
+			<div class="col-xs-10">
 				{{input type="text" value=sliderValsString class="form-control input-xl"}}
 			</div>
 		</div>
 		{{else}}
-	    <div class="form-group">
-		    <label class="col-xs-2">Value</label>
-		    <div class="col-xs-10">
+		<div class="form-group">
+			<label class="col-xs-2">Value</label>
+			<div class="col-xs-10">
 				{{input type="number" value=sliderVal class="form-control input-xl"}}
 			</div>
 		</div>
 		{{/if}}
 		<div class="form-group">
-		    <label class="col-xs-2">Step</label>
-		    <div class="col-xs-10">
+			<label class="col-xs-2">Step</label>
+			<div class="col-xs-10">
 				{{input type="number" value=sliderStep class="form-control input-xl"}}
 			</div>
 		</div>
 		<div class="form-group">
-		    <label class="col-xs-2">Range</label>
-		    <div class="col-xs-10">
+			<label class="col-xs-2">Range</label>
+			<div class="col-xs-10">
 				{{input type="checkbox" checked=isRange}}
 			</div>
 
 		</div>
 		<div class="form-group">
-		    <label class="col-xs-2">Disabled</label>
-		    <div class="col-xs-10">
+			<label class="col-xs-2">Disabled</label>
+			<div class="col-xs-10">
 				{{input type="checkbox" checked=isDisabled}}
 			</div>
 		</div>


### PR DESCRIPTION
We need to properly coerce the values we send to jQuery UI since it's expecting specific types.  This is evident in the demo if you touch the step input and then try and use the slider.  Exceptions are thrown.
