### PR TITLE
Handle array of values

### DIFF
--- a/addon/components/ember-slider.js
+++ b/addon/components/ember-slider.js
@@ -28,9 +28,9 @@ export default Ember.Component.extend({
 			},
 			change : function (event, ui) {
 				if (target.sendAction) {
-					target.sendAction('changeAction', ui.value);
+					target.sendAction('changeAction', ui.values ? ui.values : ui.value);
 				} else {
-					target.send(self.get('changeAction'), ui.value);
+					target.send(self.get('changeAction'), ui.values ? ui.values : ui.value);
 				}
 			}
 		});

--- a/addon/components/ember-slider.js
+++ b/addon/components/ember-slider.js
@@ -24,7 +24,11 @@ export default Ember.Component.extend({
 
 		var options = Ember.merge(this.getProperties(props), {
 			slide : function (event, ui) {
-				self.set('value', ui.value);
+				if (self.get('values')) {
+				  self.set('values', ui.values);
+				} else {
+				  self.set('value', ui.value);
+				}
 			},
 			change : function (event, ui) {
 				if (target.sendAction) {


### PR DESCRIPTION
This PR adds the functionality for returning `values` instead of `value` when the slider is used with a range of values
